### PR TITLE
[TRIVIAL] Fix URL to be transmitted into requestContactlessPayment RPC call

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,7 +117,7 @@ export default function Home({ searchParams }: { searchParams: any }) {
         method: 'requestContactlessPayment',
         params: [{
           type: 2,
-          uri: `${process.env.NEXT_PUBLIC_NFC_RELAYER_URL as string}/${uuid}`
+          uri: `${process.env.NEXT_PUBLIC_NFC_RELAYER_URL as string}/paymentTxParams/${uuid}`
         }],
       });
     }

--- a/app/tip/[walletAddress]/page.tsx
+++ b/app/tip/[walletAddress]/page.tsx
@@ -146,7 +146,7 @@ export default function Tip() {
       method: 'requestContactlessPayment',
       params: [{
         type: 2,
-        uri: `${process.env.NEXT_PUBLIC_NFC_RELAYER_URL as string}/${uuid}`
+        uri: `${process.env.NEXT_PUBLIC_NFC_RELAYER_URL as string}/paymentTxParams/${uuid}`
       }],
     });
   }, []);


### PR DESCRIPTION
The URL for the customer to fetch NFC relayer data from was incorrect previously